### PR TITLE
Add StatusCode, headers and error message fields to WebRequestResponse

### DIFF
--- a/Runtime/Core/WebRequestResponse.cs
+++ b/Runtime/Core/WebRequestResponse.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine.Networking;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace JeffreyLanters.WebRequests.Core {
 
@@ -15,13 +16,28 @@ namespace JeffreyLanters.WebRequests.Core {
     /// </summary>
     public string webRequestResponseText { get; private set; } = "";
 
+    public string ErrorMessage { get; private set; } = "";
+
+    /// <summary>
+    /// The response status code from the web request.
+    /// </summary>
+    public long StatusCode { get; private set; }
+
+    /// <summary>
+    /// The response headers from the web request.
+    /// </summary>
+    public Dictionary<string, string> headers { get; private set; }
+
     /// <summary>
     /// Instanciates a new web request response based of off a web request
     /// handler. The required data will be extracted from the download handler.
     /// </summary>
     /// <param name="webRequestHandler"></param>
     public WebRequestResponse (WebRequestHandler webRequestHandler) {
-      this.webRequestResponseText = webRequestHandler.downloadHandler.text;
+            this.webRequestResponseText = webRequestHandler.downloadHandler.text;
+            this.StatusCode = webRequestHandler.responseCode;
+            this.headers = webRequestHandler.GetResponseHeaders();
+            this.ErrorMessage = webRequestHandler.error;
     }
 
     /// <summary>
@@ -32,13 +48,19 @@ namespace JeffreyLanters.WebRequests.Core {
       return this.webRequestResponseText;
     }
 
-    /// <summary>
-    /// Converts the Web Request's response text as a JSON Objects to a given
-    /// data type.
-    /// </summary>
-    /// <typeparam name="DataType">The Type to convert the JSON to.</typeparam>
-    /// <returns>The Object</returns>
-    public DataType Json<DataType> () where DataType : class {
+    public string Content { get
+            {
+                return this.webRequestResponseText;
+            }
+        }
+
+        /// <summary>
+        /// Converts the Web Request's response text as a JSON Objects to a given
+        /// data type.
+        /// </summary>
+        /// <typeparam name="DataType">The Type to convert the JSON to.</typeparam>
+        /// <returns>The Object</returns>
+        public DataType Json<DataType> () where DataType : class {
       return typeof (DataType).IsArray ?
         JsonUtility.FromJson<JsonArrayWrapper<DataType>> ($"{{\"array\":{this.webRequestResponseText}}}").array :
         JsonUtility.FromJson<DataType> (this.webRequestResponseText);

--- a/Runtime/FormDataUtility.cs
+++ b/Runtime/FormDataUtility.cs
@@ -42,5 +42,15 @@ namespace JeffreyLanters.WebRequests {
       _rawFormData += "--";
       return _rawFormData;
     }
-  }
+
+    public static string QueryString(IDictionary<string, string> dict)
+    {
+        var list = new List<string>();
+        foreach (var item in dict)
+        {
+            list.Add(item.Key + "=" + item.Value);
+        }
+        return string.Join("&", list);
+    }
+    }
 }


### PR DESCRIPTION
Add helper method to convert String dictionary into QueryParameters string
Add StatusCode, headers and error message fields to WebRequestResponse

This allows us to access HTTP Status Code, headers from the response and also access the error if the request fails.
Tested on Unity 2021.3 (specially WebGL)
